### PR TITLE
Add the ability to migrate objects between rancher environments

### DIFF
--- a/cli/cmds/interactive/interactive.go
+++ b/cli/cmds/interactive/interactive.go
@@ -9,9 +9,9 @@ import (
 	"galal-hussein/cattle-drive/pkg/cluster/tui"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -53,8 +53,6 @@ func NewCommand() *cli.Command {
 
 func migrate(clx *cli.Context) error {
 	ctx := context.Background()
-	cmds.Spinner.Prefix = fmt.Sprintf("initiating source [%s] and target [%s] clusters objects.. ", source, target)
-	cmds.Spinner.Start()
 	restConfig, err := clientcmd.BuildConfigFromFlags("", cmds.Kubeconfig)
 	if err != nil {
 		return err
@@ -63,8 +61,31 @@ func migrate(clx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// check for target rancher
+	var (
+		targetRancherConfig *rest.Config
+		targetRancherClient *client.Clients
+	)
+	if cmds.TargetRancherConfig != "" {
+		targetRancherConfig, err = clientcmd.BuildConfigFromFlags("", cmds.TargetRancherConfig)
+		if err != nil {
+			return err
+		}
+		targetRancherClient, err = client.New(ctx, targetRancherConfig)
+		if err != nil {
+			return err
+		}
+	}
+	prefixMsg := fmt.Sprintf("initiating source [%s] and target [%s] clusters objects.. ", source, target)
+	if cmds.TargetRancherConfig != "" {
+		prefixMsg = fmt.Sprintf("initiating source cluster [%s] on rancher host [%s] and target cluster [%s] on rancher host [%s] ", source, restConfig.Host, target, targetRancherConfig.Host)
+	}
+	cmds.Spinner.Prefix = prefixMsg
+	cmds.Spinner.Start()
+
 	if source == "" || target == "" {
-		logrus.Fatalf("source or target is not specified")
+		return fmt.Errorf("source or target is not specified")
 	}
 
 	var clusters v3.ClusterList
@@ -74,18 +95,28 @@ func migrate(clx *cli.Context) error {
 	}
 
 	for _, cluster := range clusters.Items {
-		logrus.Debugf("check cluster: %s", cluster.Spec.DisplayName)
 		if cluster.Spec.DisplayName == source {
-			logrus.Debugf("cluster %s found", source)
 			sourceCluster = cluster.DeepCopy()
 		}
-		if cluster.Spec.DisplayName == target {
-			logrus.Debugf("cluster %s found", target)
-			targetCluster = cluster.DeepCopy()
+		if targetRancherClient == nil {
+			if cluster.Spec.DisplayName == target {
+				targetCluster = cluster.DeepCopy()
+			}
+		}
+	}
+	if targetRancherClient != nil {
+		// find the target cluster on the target rancher environment
+		if err := targetRancherClient.Clusters.List(ctx, "", &clusters, v1.ListOptions{}); err != nil {
+			return err
+		}
+		for _, cluster := range clusters.Items {
+			if cluster.Spec.DisplayName == target {
+				targetCluster = cluster.DeepCopy()
+			}
 		}
 	}
 	if sourceCluster == nil || targetCluster == nil {
-		logrus.Fatal("failed to find source or target cluster")
+		return fmt.Errorf("failed to find source or target cluster")
 	}
 	// initiate client for the cluster
 	scConfig := *restConfig
@@ -100,6 +131,10 @@ func migrate(clx *cli.Context) error {
 	}
 	tcConfig := *restConfig
 	tcConfig.Host = restConfig.Host + "/k8s/clusters/" + targetCluster.Name
+	if targetRancherClient != nil {
+		tcConfig = *targetRancherConfig
+		tcConfig.Host = targetRancherConfig.Host + "/k8s/clusters/" + targetCluster.Name
+	}
 	tcClient, err := client.New(ctx, &tcConfig)
 	if err != nil {
 		return err
@@ -112,12 +147,18 @@ func migrate(clx *cli.Context) error {
 	if err := sc.Populate(ctx, cl); err != nil {
 		return err
 	}
-	if err := tc.Populate(ctx, cl); err != nil {
-		return err
+	if targetRancherClient != nil {
+		if err := tc.Populate(ctx, targetRancherClient); err != nil {
+			return err
+		}
+	} else {
+		if err := tc.Populate(ctx, cl); err != nil {
+			return err
+		}
 	}
-	if err := sc.Compare(ctx, cl, tc); err != nil {
+	if err := sc.Compare(ctx, tc); err != nil {
 		return err
 	}
 	cmds.Spinner.Stop()
-	return tui.StartTea(sc, tc, cl, logFilePath)
+	return tui.StartTea(sc, tc, cl, targetRancherClient, logFilePath)
 }

--- a/cli/cmds/interactive/interactive.go
+++ b/cli/cmds/interactive/interactive.go
@@ -143,7 +143,11 @@ func migrate(clx *cli.Context) error {
 		Obj:    targetCluster,
 		Client: tcClient,
 	}
-
+	// check if the target cluster is in external rancher environment then set external rancher to true
+	if targetRancherClient != nil {
+		tc.ExternalRancher = true
+		sc.ExternalRancher = true
+	}
 	if err := sc.Populate(ctx, cl); err != nil {
 		return err
 	}

--- a/cli/cmds/migrate/migrate.go
+++ b/cli/cmds/migrate/migrate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -45,8 +46,6 @@ func NewCommand() *cli.Command {
 
 func migrate(clx *cli.Context) error {
 	ctx := context.Background()
-	cmds.Spinner.Prefix = fmt.Sprintf("initiating source [%s] and target [%s] clusters objects.. ", source, target)
-	cmds.Spinner.Start()
 	restConfig, err := clientcmd.BuildConfigFromFlags("", cmds.Kubeconfig)
 	if err != nil {
 		return err
@@ -55,8 +54,30 @@ func migrate(clx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	// check for target rancher
+	var (
+		targetRancherConfig *rest.Config
+		targetRancherClient *client.Clients
+	)
+	if cmds.TargetRancherConfig != "" {
+		targetRancherConfig, err = clientcmd.BuildConfigFromFlags("", cmds.TargetRancherConfig)
+		if err != nil {
+			return err
+		}
+		targetRancherClient, err = client.New(ctx, targetRancherConfig)
+		if err != nil {
+			return err
+		}
+	}
+	prefixMsg := fmt.Sprintf("initiating source [%s] and target [%s] clusters objects.. ", source, target)
+	if cmds.TargetRancherConfig != "" {
+		prefixMsg = fmt.Sprintf("initiating source cluster [%s] on rancher host [%s] and target cluster [%s] on rancher host [%s] ", source, restConfig.Host, target, targetRancherConfig.Host)
+	}
+	cmds.Spinner.Prefix = prefixMsg
+	cmds.Spinner.Start()
+
 	if source == "" || target == "" {
-		logrus.Fatalf("source or target is not specified")
+		return fmt.Errorf("source or target is not specified")
 	}
 
 	var clusters v3.ClusterList
@@ -66,14 +87,24 @@ func migrate(clx *cli.Context) error {
 	}
 
 	for _, cluster := range clusters.Items {
-		logrus.Debugf("check cluster: %s", cluster.Spec.DisplayName)
 		if cluster.Spec.DisplayName == source {
-			logrus.Debugf("cluster %s found", source)
 			sourceCluster = cluster.DeepCopy()
 		}
-		if cluster.Spec.DisplayName == target {
-			logrus.Debugf("cluster %s found", target)
-			targetCluster = cluster.DeepCopy()
+		if targetRancherClient == nil {
+			if cluster.Spec.DisplayName == target {
+				targetCluster = cluster.DeepCopy()
+			}
+		}
+	}
+	if targetRancherClient != nil {
+		// find the target cluster on the target rancher environment
+		if err := targetRancherClient.Clusters.List(ctx, "", &clusters, v1.ListOptions{}); err != nil {
+			return err
+		}
+		for _, cluster := range clusters.Items {
+			if cluster.Spec.DisplayName == target {
+				targetCluster = cluster.DeepCopy()
+			}
 		}
 	}
 	if sourceCluster == nil || targetCluster == nil {
@@ -92,6 +123,10 @@ func migrate(clx *cli.Context) error {
 	}
 	tcConfig := *restConfig
 	tcConfig.Host = restConfig.Host + "/k8s/clusters/" + targetCluster.Name
+	if targetRancherClient != nil {
+		tcConfig = *targetRancherConfig
+		tcConfig.Host = targetRancherConfig.Host + "/k8s/clusters/" + targetCluster.Name
+	}
 	tcClient, err := client.New(ctx, &tcConfig)
 	if err != nil {
 		return err
@@ -103,12 +138,21 @@ func migrate(clx *cli.Context) error {
 	if err := sc.Populate(ctx, cl); err != nil {
 		return err
 	}
-	if err := tc.Populate(ctx, cl); err != nil {
-		return err
+	if targetRancherClient != nil {
+		if err := tc.Populate(ctx, targetRancherClient); err != nil {
+			return err
+		}
+	} else {
+		if err := tc.Populate(ctx, cl); err != nil {
+			return err
+		}
 	}
-	if err := sc.Compare(ctx, cl, tc); err != nil {
+	if err := sc.Compare(ctx, tc); err != nil {
 		return err
 	}
 	cmds.Spinner.Stop()
+	if targetRancherClient != nil {
+		return sc.Migrate(ctx, targetRancherClient, tc, os.Stdout)
+	}
 	return sc.Migrate(ctx, cl, tc, os.Stdout)
 }

--- a/cli/cmds/migrate/migrate.go
+++ b/cli/cmds/migrate/migrate.go
@@ -135,6 +135,11 @@ func migrate(clx *cli.Context) error {
 		Obj:    targetCluster,
 		Client: tcClient,
 	}
+	// check if the target cluster is in external rancher environment then set external rancher to true
+	if targetRancherClient != nil {
+		tc.ExternalRancher = true
+		sc.ExternalRancher = true
+	}
 	if err := sc.Populate(ctx, cl); err != nil {
 		return err
 	}

--- a/cli/cmds/root.go
+++ b/cli/cmds/root.go
@@ -8,13 +8,20 @@ import (
 )
 
 var (
-	Kubeconfig  string
-	CommonFlags = []cli.Flag{
+	Kubeconfig          string
+	TargetRancherConfig string
+	CommonFlags         = []cli.Flag{
 		&cli.StringFlag{
 			Name:        "kubeconfig",
 			EnvVars:     []string{"KUBECONFIG"},
 			Usage:       "Kubeconfig path",
 			Destination: &Kubeconfig,
+		},
+		&cli.StringFlag{
+			Name:        "target-rancher-config",
+			EnvVars:     []string{"TARGET_RANCHER"},
+			Usage:       "(experimental) migrate cluster objects to another rancher deployment",
+			Destination: &TargetRancherConfig,
 		},
 	}
 	Spinner *spinner.Spinner

--- a/cli/cmds/status/status.go
+++ b/cli/cmds/status/status.go
@@ -8,9 +8,9 @@ import (
 	"galal-hussein/cattle-drive/pkg/cluster"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -44,8 +44,6 @@ func NewCommand() *cli.Command {
 
 func status(clx *cli.Context) error {
 	ctx := context.Background()
-	cmds.Spinner.Prefix = fmt.Sprintf("initiating source [%s] and target [%s] clusters objects.. ", source, target)
-	cmds.Spinner.Start()
 	restConfig, err := clientcmd.BuildConfigFromFlags("", cmds.Kubeconfig)
 	if err != nil {
 		return err
@@ -54,8 +52,30 @@ func status(clx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	// check for target rancher
+	var (
+		targetRancherConfig *rest.Config
+		targetRancherClient *client.Clients
+	)
+	if cmds.TargetRancherConfig != "" {
+		targetRancherConfig, err = clientcmd.BuildConfigFromFlags("", cmds.TargetRancherConfig)
+		if err != nil {
+			return err
+		}
+		targetRancherClient, err = client.New(ctx, targetRancherConfig)
+		if err != nil {
+			return err
+		}
+	}
+	prefixMsg := fmt.Sprintf("initiating source [%s] and target [%s] clusters objects.. ", source, target)
+	if cmds.TargetRancherConfig != "" {
+		prefixMsg = fmt.Sprintf("initiating source cluster [%s] on rancher host [%s] and target cluster [%s] on rancher host [%s] ", source, restConfig.Host, target, targetRancherConfig.Host)
+	}
+	cmds.Spinner.Prefix = prefixMsg
+	cmds.Spinner.Start()
+
 	if source == "" || target == "" {
-		logrus.Fatalf("source or target is not specified")
+		return fmt.Errorf("source or target is not specified")
 	}
 
 	var clusters v3.ClusterList
@@ -65,18 +85,29 @@ func status(clx *cli.Context) error {
 	}
 
 	for _, cluster := range clusters.Items {
-		logrus.Debugf("check cluster: %s", cluster.Spec.DisplayName)
 		if cluster.Spec.DisplayName == source {
-			logrus.Debugf("cluster %s found", source)
 			sourceCluster = cluster.DeepCopy()
 		}
-		if cluster.Spec.DisplayName == target {
-			logrus.Debugf("cluster %s found", target)
-			targetCluster = cluster.DeepCopy()
+		// adding this check to avoid same target name on the wrong rancher environment
+		if targetRancherClient == nil {
+			if cluster.Spec.DisplayName == target {
+				targetCluster = cluster.DeepCopy()
+			}
+		}
+	}
+	if targetRancherClient != nil {
+		// find the target cluster on the target rancher environment
+		if err := targetRancherClient.Clusters.List(ctx, "", &clusters, v1.ListOptions{}); err != nil {
+			return err
+		}
+		for _, cluster := range clusters.Items {
+			if cluster.Spec.DisplayName == target {
+				targetCluster = cluster.DeepCopy()
+			}
 		}
 	}
 	if sourceCluster == nil || targetCluster == nil {
-		logrus.Fatal("failed to find source or target cluster")
+		return fmt.Errorf("failed to find source or target cluster")
 	}
 	// initiate client for the cluster
 	scConfig := *restConfig
@@ -91,6 +122,10 @@ func status(clx *cli.Context) error {
 	}
 	tcConfig := *restConfig
 	tcConfig.Host = restConfig.Host + "/k8s/clusters/" + targetCluster.Name
+	if targetRancherClient != nil {
+		tcConfig = *targetRancherConfig
+		tcConfig.Host = targetRancherConfig.Host + "/k8s/clusters/" + targetCluster.Name
+	}
 	tcClient, err := client.New(ctx, &tcConfig)
 	if err != nil {
 		return err
@@ -102,12 +137,18 @@ func status(clx *cli.Context) error {
 	if err := sc.Populate(ctx, cl); err != nil {
 		return err
 	}
-	if err := tc.Populate(ctx, cl); err != nil {
-		return err
+	if targetRancherClient != nil {
+		if err := tc.Populate(ctx, targetRancherClient); err != nil {
+			return err
+		}
+	} else {
+		if err := tc.Populate(ctx, cl); err != nil {
+			return err
+		}
 	}
-	if err := sc.Compare(ctx, cl, tc); err != nil {
+	if err := sc.Compare(ctx, tc); err != nil {
 		return err
 	}
 	cmds.Spinner.Stop()
-	return sc.Status(ctx, cl)
+	return sc.Status(ctx)
 }

--- a/cli/cmds/status/status.go
+++ b/cli/cmds/status/status.go
@@ -134,6 +134,11 @@ func status(clx *cli.Context) error {
 		Obj:    targetCluster,
 		Client: tcClient,
 	}
+	// check if the target cluster is in external rancher environment then set external rancher to true
+	if targetRancherClient != nil {
+		tc.ExternalRancher = true
+		sc.ExternalRancher = true
+	}
 	if err := sc.Populate(ctx, cl); err != nil {
 		return err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -21,6 +21,7 @@ type Clients struct {
 	ClusterRegistrationTokens   *client.Client
 	Users                       *client.Client
 	ClusterRepos                *client.Client
+	GlobalRoleBindings          *client.Client
 	ConfigMaps                  v1.ConfigMapClient
 	Namespace                   v1.NamespaceClient
 }
@@ -58,6 +59,7 @@ func New(ctx context.Context, rest *rest.Config) (*Clients, error) {
 		ClusterRoleTemplateBindings: NewClient(factory, "management.cattle.io", "v3", "clusterRoleTemplateBindings", "ClusterRoleTemplateBinding", true),
 		ClusterRegistrationTokens:   NewClient(factory, "management.cattle.io", "v3", "clusterRegistrationTokens", "ClusterRegistrationToken", false),
 		ClusterRepos:                NewClient(factory, "catalog.cattle.io", "v1", "clusterRepos", "ClusterRepo", false),
+		GlobalRoleBindings:          NewClient(factory, "management.cattle.io", "v3", "globalRoleBindings", "GlobalRoleBinding", false),
 	}, nil
 }
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -133,7 +133,7 @@ func (c *Cluster) Populate(ctx context.Context, client *client.Clients) error {
 }
 
 // Compare will compare between objects of downstream source cluster and target cluster
-func (c *Cluster) Compare(ctx context.Context, client *client.Clients, tc *Cluster) error {
+func (c *Cluster) Compare(ctx context.Context, tc *Cluster) error {
 	// projects
 	for _, sProject := range c.ToMigrate.Projects {
 		for _, tProject := range tc.ToMigrate.Projects {
@@ -205,7 +205,7 @@ func (c *Cluster) Compare(ctx context.Context, client *client.Clients, tc *Clust
 	return nil
 }
 
-func (c *Cluster) Status(ctx context.Context, client *client.Clients) error {
+func (c *Cluster) Status(ctx context.Context) error {
 	fmt.Printf("Project status:\n")
 	for _, p := range c.ToMigrate.Projects {
 		print(p.Name, p.Migrated, p.Diff, 0)

--- a/pkg/cluster/clusterroletemplatebinding.go
+++ b/pkg/cluster/clusterroletemplatebinding.go
@@ -63,6 +63,10 @@ func (c *ClusterRoleTemplateBinding) SetDescription(ctx context.Context, client 
 	if err := client.Users.Get(ctx, "", userID, &user, v1.GetOptions{}); err != nil {
 		return err
 	}
-	c.Description = fmt.Sprintf("%s permission for user %s", c.Obj.RoleTemplateName, user.DisplayName)
+	name := user.DisplayName
+	if name == "" {
+		name = user.Username
+	}
+	c.Description = fmt.Sprintf("%s permission for user %s", c.Obj.RoleTemplateName, name)
 	return nil
 }

--- a/pkg/cluster/globalrolebinding.go
+++ b/pkg/cluster/globalrolebinding.go
@@ -1,0 +1,52 @@
+package cluster
+
+import (
+	"fmt"
+	"strings"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+)
+
+type GlobalRoleBinding struct {
+	Name        string
+	Obj         *v3.GlobalRoleBinding
+	Description string
+	Migrated    bool
+	Diff        bool
+}
+
+func newGRB(obj v3.GlobalRoleBinding) *GlobalRoleBinding {
+	return &GlobalRoleBinding{
+		Name:     obj.Name,
+		Obj:      obj.DeepCopy(),
+		Migrated: false,
+	}
+}
+
+// normalize will remove unneeded fields in the spec to make it easier to compare
+func (g *GlobalRoleBinding) normalize() {
+	for _, or := range g.Obj.OwnerReferences {
+		or.UID = ""
+	}
+}
+
+func (g *GlobalRoleBinding) Mutate() {
+	g.Obj.SetName(g.Name)
+	g.Obj.SetFinalizers(nil)
+	g.Obj.SetResourceVersion("")
+	g.Obj.SetLabels(nil)
+	for annotation := range g.Obj.Annotations {
+		if strings.Contains(annotation, lifeCycleAnnotationPrefix) {
+			delete(g.Obj.Annotations, annotation)
+		}
+		if strings.Contains(annotation, "authz.management.cattle.io/crb-name") {
+			delete(g.Obj.Annotations, annotation)
+		}
+	}
+}
+
+func (g *GlobalRoleBinding) SetDescription(user v3.User) error {
+
+	g.Description = fmt.Sprintf("%s permission for user %s", g.Obj.GlobalRoleName, user.Username)
+	return nil
+}

--- a/pkg/cluster/project.go
+++ b/pkg/cluster/project.go
@@ -51,4 +51,8 @@ func (p *Project) Mutate(c *Cluster) {
 			delete(p.Obj.Annotations, annotation)
 		}
 	}
+	if c.ExternalRancher {
+		p.Obj.Annotations["field.cattle.io/creatorId"] = c.DefaultAdmin.Name
+		p.Obj.Annotations["authz.management.cattle.io/creator-role-bindings"] = `{"required":["project-owner"]}`
+	}
 }

--- a/pkg/cluster/projectroletemplatebinding.go
+++ b/pkg/cluster/projectroletemplatebinding.go
@@ -17,8 +17,7 @@ type ProjectRoleTemplateBinding struct {
 	ProjectDisplayName string
 	Migrated           bool
 	Diff               bool
-	// Description only exists for PRTB and CRTB
-	Description string
+	Description        string
 }
 
 func newPRTB(obj v3.ProjectRoleTemplateBinding, projectName, projectDisplayName string) *ProjectRoleTemplateBinding {
@@ -59,6 +58,10 @@ func (p *ProjectRoleTemplateBinding) SetDescription(ctx context.Context, client 
 	if err := client.Users.Get(ctx, "", userID, &user, v1.GetOptions{}); err != nil {
 		return err
 	}
-	p.Description = fmt.Sprintf("%s permission for user %s", p.Obj.RoleTemplateName, user.DisplayName)
+	name := user.DisplayName
+	if name == "" {
+		name = user.Username
+	}
+	p.Description = fmt.Sprintf("%s permission for user %s", p.Obj.RoleTemplateName, name)
 	return nil
 }

--- a/pkg/cluster/tui/cluster.go
+++ b/pkg/cluster/tui/cluster.go
@@ -75,6 +75,9 @@ func newClusterList() []list.Item {
 		item{title: "Cluster User Permissions", desc: "user permissions for the cluster (CRTB)", objType: constants.CRTBsType, obj: nil},
 		item{title: "Catalog Repos", desc: "Cluster apps repos", objType: constants.ReposType, obj: nil},
 	}
+	if constants.TC.ExternalRancher || constants.SC.ExternalRancher {
+		items = append(items, item{title: "Users", desc: "Rancher Users", objType: constants.UsersType, obj: nil})
+	}
 	return items
 }
 

--- a/pkg/cluster/tui/cluster.go
+++ b/pkg/cluster/tui/cluster.go
@@ -141,7 +141,11 @@ func (m Model) View() string {
 
 func (m *Model) migrateCluster(ctx context.Context) {
 	fmt.Fprintf(&constants.LogFile, "[%s] initiating cluster objects migrate:\n", time.Now().String())
-	if err := constants.SC.Migrate(ctx, constants.Lclient, constants.TC, &constants.LogFile); err != nil {
+	cl := constants.TClient
+	if cl == nil {
+		cl = constants.Lclient
+	}
+	if err := constants.SC.Migrate(ctx, cl, constants.TC, &constants.LogFile); err != nil {
 		fmt.Fprintf(&constants.LogFile, "[%s] [error] %v\n", time.Now().String(), err)
 		m.Update(tea.Quit())
 	}

--- a/pkg/cluster/tui/constants/constants.go
+++ b/pkg/cluster/tui/constants/constants.go
@@ -30,6 +30,8 @@ const (
 	NamespaceType  = "namespace"
 	PRTBType       = "prtb"
 	RepoType       = "repo"
+	UsersType      = "users"
+	UserType       = "user"
 )
 
 type MigrationStatus int

--- a/pkg/cluster/tui/constants/constants.go
+++ b/pkg/cluster/tui/constants/constants.go
@@ -41,8 +41,10 @@ var (
 	SC *cluster.Cluster
 	// TC the target cluster
 	TC *cluster.Cluster
-	// Local Client
+	// Local Rancher Client
 	Lclient *client.Clients
+	// Target Rancher Client
+	TClient *client.Clients
 	// WindowSize store the size of the terminal window
 	WindowSize tea.WindowSizeMsg
 	// Migratedch all object chan

--- a/pkg/cluster/tui/objects.go
+++ b/pkg/cluster/tui/objects.go
@@ -153,7 +153,7 @@ func (m Objects) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				entry := InitObjects(item)
 				return entry.Update(constants.WindowSize)
 			}
-			if item.objType == constants.PRTBsType || item.objType == constants.NamespacesType || item.objType == constants.UsersType {
+			if item.objType == constants.PRTBsType || item.objType == constants.NamespacesType {
 				entry := InitObjects(item)
 				return entry.Update(constants.WindowSize)
 			}

--- a/pkg/cluster/tui/tui.go
+++ b/pkg/cluster/tui/tui.go
@@ -11,7 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func StartTea(sc, tc *cluster.Cluster, client *client.Clients, logFilePath string) error {
+func StartTea(sc, tc *cluster.Cluster, client, tClient *client.Clients, logFilePath string) error {
 	if f, err := tea.LogToFile(logFilePath, "help"); err != nil {
 		fmt.Println("Couldn't open a file for logging:", err)
 		os.Exit(1)
@@ -27,6 +27,7 @@ func StartTea(sc, tc *cluster.Cluster, client *client.Clients, logFilePath strin
 	constants.SC = sc
 	constants.TC = tc
 	constants.Lclient = client
+	constants.TClient = tClient
 
 	m, _ := InitCluster(nil)
 	constants.P = tea.NewProgram(m, tea.WithAltScreen())

--- a/pkg/cluster/user.go
+++ b/pkg/cluster/user.go
@@ -1,0 +1,40 @@
+package cluster
+
+import (
+	"strings"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+)
+
+type User struct {
+	Name               string
+	Obj                *v3.User
+	Migrated           bool
+	Diff               bool
+	GlobalRoleBindings []*GlobalRoleBinding
+}
+
+func newUser(obj v3.User, grbList []*GlobalRoleBinding) *User {
+	return &User{
+		Name:               obj.Name,
+		Obj:                obj.DeepCopy(),
+		GlobalRoleBindings: grbList,
+		Migrated:           false,
+	}
+}
+
+// normalize will remove unneeded fields in the spec to make it easier to compare
+func (u *User) normalize() {
+}
+
+func (u *User) Mutate() {
+	u.Obj.SetName(u.Name)
+	u.Obj.SetFinalizers(nil)
+	u.Obj.SetResourceVersion("")
+	u.Obj.SetLabels(nil)
+	for annotation := range u.Obj.Annotations {
+		if strings.Contains(annotation, lifeCycleAnnotationPrefix) {
+			delete(u.Obj.Annotations, annotation)
+		}
+	}
+}


### PR DESCRIPTION
- Add the ability to migrate cluster objects and artifacts between rancher environments
  - add --external-rancher-config flag
- Add user migration as well in case of external rancher